### PR TITLE
fix floats

### DIFF
--- a/encodings.js
+++ b/encodings.js
@@ -230,7 +230,7 @@ exports.float = function() {
   }
 
   var decode = function(buffer, offset) {
-    var val = buffer.readFloadLE(offset)
+    var val = buffer.readFloatLE(offset)
     decode.bytes = 4
     return val
   }

--- a/test/float.js
+++ b/test/float.js
@@ -3,32 +3,23 @@ var path = require('path')
 var protobuf = require('../require')
 var Float = protobuf('./test.proto').Float
 
-tape('integers encode + decode', function(t) {
-  var b1 = Float.encode({
-    float: 1.1
-  })
+tape('float encode + decode', function(t) {
+  var arr = new Float32Array(3)
+  arr[0] = 1.1
+  arr[1] = 0
+  arr[2] = -2.3
+  
+  var obj = {
+    float1: arr[0],
+    float2: arr[1],
+    float3: arr[2]
+  }
+  
+  var b1 = Float.encode(obj)
 
   var o1 = Float.decode(b1)
 
-  t.same(o1, {
-    float: 1.1
-  })
-
-  t.end()
-})
-
-tape('integers encode + decode + negative', function(t) {
-  var b1 = Float.encode({
-    float: 0,
-    float2: -1.1
-  })
-
-  var o1 = Float.decode(b1)
-
-  t.same(o1, {
-    float: 0,
-    float2: -1.1
-  })
+  t.same(o1, obj)
 
   t.end()
 })

--- a/test/test.proto
+++ b/test/test.proto
@@ -21,8 +21,9 @@ message Integers {
 }
 
 message Float {
-  optional float float = 1;
+  optional float float1 = 1;
   optional float float2 = 2;
+  optional float float3 = 3;
 }
 
 message Packed {


### PR DESCRIPTION
just a minor typo (buffer.readFloadLE)

other than that im not sure why but the test still doesnt pass for me because of some precision error

```
# float encode + decode
not ok 7 should be equivalent
  ---
    operator: deepEqual
    expected: { float: 1.1 }
    actual:   { float: 1.100000023841858, float2: 0 }
    at: Test.Float.encode.float (/home/patrick/dev/lib/protocol-buffers/test/float.js:13:5)
  ...
# float encode + decode + negative
not ok 8 should be equivalent
  ---
    operator: deepEqual
    expected: { float: 0, float2: -1.1 }
    actual:   { float: 0, float2: -1.100000023841858 }
    at: Test.<anonymous> (/home/patrick/dev/lib/protocol-buffers/test/float.js:28:5)
  ...
```
