### PR TITLE
initialize repeated enums with []

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -265,8 +265,12 @@ module.exports = function(schema, extraEncodings) {
       var vals = resolved && resolved.values
 
       if (vals) { // is enum
-        def = (def && def in vals) ? vals[def] : vals[Object.keys(vals)[0]]
-        Message('%s = %s', genobj('this', f.name), ''+parseInt(def || 0))
+        if (f.repeated) {
+          Message('%s = []', genobj('this', f.name))
+        } else {
+          def = (def && def in vals) ? vals[def] : vals[Object.keys(vals)[0]]
+          Message('%s = %s', genobj('this', f.name), ''+parseInt(def || 0))
+        }
         return
       }
 


### PR DESCRIPTION
This solves a traceback for parsing relation MemberTypes of the OSM PBF schema:

```
undefined:70
        obj.types.push(enc[6].decode(buf, offset))
                  ^
TypeError: Object 0 has no method 'push'
    at Object.decode (eval at <anonymous> (osm-pbf-parser/node_modules/protocol-buffers/node_modules/generate-function/index.js:1:0), <anonymous>:70:19)
    at Object.decode (eval at <anonymous> (osm-pbf-parser/node_modules/protocol-buffers/node_modules/generate-function/index.js:1:0), <anonymous>:37:33)
    at Object.decode (eval at <anonymous> (osm-pbf-parser/node_modules/protocol-buffers/node_modules/generate-function/index.js:1:0), <anonymous>:28:38)
    at osm-pbf-parser/index.js:81:56
```

I must admit that I don't really know what I'm doing here. This code is way too mad sciency.
