### PR TITLE
add Buffer to encode scope

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -251,7 +251,8 @@ module.exports = function(schema, extraEncodings) {
       encodingLength: encodingLength,
       defined: defined,
       varint: varint,
-      enc: enc
+      enc: enc,
+      Buffer: Buffer
     })
 
     // compile proto


### PR DESCRIPTION
This allows `protocol-buffers` to be browserified!

Currently `Buffer` is undefined when calling `encode` without a `buf` arg.
