### PR TITLE
Fixed protobuf imports with respect to root_dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(proto, opts) {
   if (!opts) opts = {}
   if (!proto) throw new Error('Pass in a .proto string or a protobuf-schema parsed object')
 
-  var sch = (typeof proto === 'object' && !Buffer.isBuffer(proto)) ? proto : schema.parse(proto)
+  var sch = (typeof proto === 'object' && !Buffer.isBuffer(proto)) ? proto : schema.parse(proto, opts)
 
   // to not make toString,toJSON enumarable we make a fire-and-forget prototype
   var Messages = function() {

--- a/require.js
+++ b/require.js
@@ -6,5 +6,5 @@ var protobuf = require('./')
 delete require.cache[require.resolve(__filename)]
 
 module.exports = function(filename, opts) {
-  return protobuf(resolve.sync(path.resolve(path.dirname(module.parent.filename), filename)), opts)
+  return protobuf(resolve.sync(path.resolve(path.dirname(module.parent.filename), filename), opts))
 }


### PR DESCRIPTION
This is one of 2 pull requests across protocol-buffer and resolve-protobuf-schema repositories that fixes imports of external protobuf files. now you can specify root_dir that defines base place from where all files are looked-up (as defined in protobuf specification: https://developers.google.com/protocol-buffers/docs/proto#other. 
You need to test it together with https://github.com/mafintosh/protobuf-schema/pull/6.
