### PR TITLE
Updated default value handling for optional fields

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -44,14 +44,17 @@ var defaultValue = function(f, def) {
 
   switch (f.type) {
     case 'string':
-    return isString(def) ? def : '""'
+    return isString(def) ? def : 'null'
 
     case 'bool':
     if (def === 'true') return 'true'
-    return 'false'
+    if (def === 'false') return 'false'
+    return 'null'
 
     case 'float':
     case 'double':
+    return (def != null)? '' + parseFloat(def): 'null'
+
     case 'sfixed32':
     case 'fixed32':
     case 'varint':
@@ -62,7 +65,7 @@ var defaultValue = function(f, def) {
     case 'int32':
     case 'sint64':
     case 'sint32':
-    return ''+parseInt(def || 0)
+    return (def != null)? '' + parseInt(def): 'null'
 
     default:
     return 'null'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "varint": "^3.0.0"
   },
   "devDependencies": {
-    "tape": "^2.13.4"
+    "tape": "^2.13.4",
+    "benchmark": "^1.0.0"
   },
   "scripts": {
     "test": "tape test/*.js",

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -19,7 +19,9 @@ tape('defaults decode', function(t) {
     num: 10,
     foo1: 2,
     foo2: 2,
-    foos: []
+    foos: [],
+    float_value:  4.932,
+    double_value: 1.2322
   }, '1 default')
 
   t.same(o1, {
@@ -27,13 +29,17 @@ tape('defaults decode', function(t) {
     foo1: 2,
     foo2: 1,
     foos: [],
+    float_value:  4.932,
+    double_value: 1.2322
   }, 'all defaults')
 
   t.same(Defaults.decode(b2), {
     num: 10,
     foo1: 2,
     foo2: 1,
-    foos: [1]
+    foos: [1],
+    float_value:  4.932,
+    double_value: 1.2322
   }, '2 defaults')
 
   t.end()

--- a/test/optional.js
+++ b/test/optional.js
@@ -1,0 +1,53 @@
+var tape = require('tape')
+var protobuf = require('../require')
+var Optional = protobuf('./test.proto').Optional
+
+tape('defaults decode null', function(t) {
+  var emptyBuffer = new Buffer(0)
+  var floats = new Float32Array(1)  // floats require special handling for equality
+  floats[0] = 4.3234
+  var partialObj = {
+    'int32': 12345,
+    'float': floats[0],
+    'double': 12.49342,
+    'string': 'foo'
+  }
+  var partialBuffer = Optional.encode(partialObj)
+  console.log(JSON.stringify(Optional.decode(partialBuffer)))
+
+  t.same(Optional.decode(emptyBuffer), {
+    "sint32": null,
+    "sint64": null,
+    "int32": null,
+    "uint32": null,
+    "int64": null,
+    "float": null,
+    "double": null,
+    "string": null,
+    "bool": null,
+    "int32_default": 46,
+    "float_default": 4.932,
+    "double_default": 1.2322,
+    "string_default": "foo",
+    "bool_default": true
+  }, 'all defaults')
+
+  t.same(Optional.decode(partialBuffer), {
+    "sint32": null,
+    "sint64": null,
+    "int32": 12345,
+    "uint32": null,
+    "int64": null,
+    "float": floats[0],
+    "double": 12.49342,
+    "string": "foo",
+    "bool": null,
+    "int32_default": 46,
+    "float_default": 4.932,
+    "double_default": 1.2322,
+    "string_default": "foo",
+    "bool_default": true
+  }, 'partial defaults')
+
+  t.end()
+})

--- a/test/test.proto
+++ b/test/test.proto
@@ -47,4 +47,24 @@ message Defaults {
   optional FOO foo1 = 2 [default = B];
   optional FOO foo2 = 3;
   repeated FOO foos = 4;
+  optional float float_value = 5 [default = 4.932];
+  optional double double_value = 6 [default = 1.2322];
+}
+
+message Optional {
+  optional sint32 sint32 = 1;
+  optional sint64 sint64 = 2;
+  optional int32 int32 = 3;
+  optional uint32 uint32 = 4;
+  optional int64 int64 = 5;
+  optional float float = 6;
+  optional double double = 7;
+  optional string string = 8;
+  optional bool bool = 9;
+
+  optional int32 int32_default = 10 [default = 46];
+  optional float float_default = 11 [default = 4.932];
+  optional double double_default = 12 [default = 1.2322];
+  optional string string_default = 13 [default = "foo"];
+  optional bool bool_default = 14 [default = true];
 }


### PR DESCRIPTION
This resolves #20 

This PR sets default values to `null` during decoding for all optional fields that do not have default values assigned in the schema.

It adds support for `float` and `double` default values defined in the schema.

It migrates the benchmarks to use [benchmarks.js](https://github.com/bestiejs/benchmark.js) to make it easier to add additional benchmarks.  Note the new dependency in `package.json`.

To compare the performance of this PR to `master`, simply copy `bench/index.js` to a new, nonversioned file and run that directly in the `master` branch.  I was getting comparable numbers between this PR and `master` within the range of variability between tests in general.

This adds new tests of optional fields.
