### PR TITLE
Expose nested enums

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -132,6 +132,10 @@ module.exports = function(schema, extraEncodings) {
     exports.message = true
     exports.name = m.name
 
+    m.enums.forEach(function( val ) {
+      exports[ val.name ] = val.values
+    })
+
     var enc = m.fields.map(function(f, i) {
       return resolve(f.type, m.id)
     })


### PR DESCRIPTION
Not sure if this was the right place to put this, but it was an easy enough change, so I figured I'd give it a shot.

Anyway, this allows access to an `enum` that's *inside* of a message – which seemed to not be possible previously.

So given `test.proto`:

```
message Foo {
  enum Baz {
    BING = 0;
    BOOM = 1;
  }
  required string bar = 1;
  required Baz baz = 2;
}
```

I can now do this:

```js
var fs = require('fs');
var protobuf = require('protocol-buffers');
var messages = protobuf( fs.readFileSync('test.proto') );

var buf = messages.Foo.encode({
  bar: 'bar',
  baz: messages.Foo.Baz.BING
});

console.log( messages.Foo.Baz.BING );

console.log( messages.Foo.decode( buf ) );
```