### PR TITLE
Added oneof support

### DIFF
--- a/test/oneof.js
+++ b/test/oneof.js
@@ -1,0 +1,58 @@
+var tape = require('tape')
+var path = require('path')
+var protobuf = require('../require')
+var proto = protobuf('./test.proto')
+var Property = proto.Property
+var PropertyNoOneof = proto.PropertyNoOneof
+
+var data = {
+  name: 'Foo',
+  desc: 'optional description',
+  int_value: 12345
+}
+
+tape('oneof encode', function(t) {
+  t.ok(Property.encode(data), 'oneof encode')
+  t.end()
+})
+
+tape('oneof encode + decode', function(t) {
+  var buf = Property.encode(data);
+  var out = Property.decode(buf)
+  t.deepEqual(data, out)
+  t.end()
+})
+
+tape('oneof encode + decode of overloaded oneof json', function(t) {
+  var invalidData = {
+    name: 'Foo',
+    desc: 'optional description',
+    string_value: 'Bar', // ignored
+    bool_value:  true,  // ignored
+    int_value: 12345 // retained, was last entered
+  }
+  var buf = Property.encode(invalidData);
+  var out = Property.decode(buf)
+  t.deepEqual(data, out)
+  t.end()
+})
+
+tape('oneof encode + decode of overloaded oneof buffer', function(t) {
+  var invalidData = {
+    name: 'Foo',
+    desc: 'optional description',
+    string_value: 'Bar', // retained, has highest tag number
+    bool_value:  true,  // ignored
+    int_value: 12345 // ignored
+  }
+  var validData = {
+    name: 'Foo',
+    desc: 'optional description',
+    string_value: 'Bar'
+  }
+
+  var buf = PropertyNoOneof.encode(invalidData);
+  var out = Property.decode(buf)
+  t.deepEqual(validData, out)
+  t.end()
+})

--- a/test/test.proto
+++ b/test/test.proto
@@ -48,3 +48,43 @@ message Defaults {
   optional FOO foo2 = 3;
   repeated FOO foos = 4;
 }
+
+message Property {
+  required string name = 1;
+  optional string desc = 2;
+  
+  oneof value {
+    bool bool_value  = 3;
+    float float_value = 4;
+    int32 int_value = 5;
+    string string_value = 6;
+  }
+}
+
+message PropertyNoOneof {
+  required string name = 1;
+  optional string desc = 2;
+
+  optional bool bool_value  = 3;
+  optional float float_value = 4;
+  optional int32 int_value = 5;
+  optional string string_value = 6;
+}
+
+message ComplexProperty {
+  required string name = 1;
+  
+  oneof value {
+    bool bool_value  = 3;
+    float float_value = 4;
+    int32 int_value = 5;
+    string string_value = 6;
+  }
+
+  oneof another_value {
+    bool bool_value  = 7;
+    float float_value = 8;
+    int32 int_value = 9;
+    string string_value = 10;
+  }
+}


### PR DESCRIPTION
This PR adds support for ```oneof``` fields, and resolves #16 

It does so by tracking which fields are ```oneof``` type and only encodes the last field defined with a value.

When decoding, and multiple ```oneof``` values are found in the buffer, it keeps only the one with the highest tag number in the ```proto``` file.

Because it is modifying the objects during encoding and decoding, there is likely a definite performance hit for using ```oneof``` fields compared to otherwise, but this may be a reasonable tradeoff for the benefits of using ```oneof```.  May be a good note for the README.md  (I did not add one there).