### PR TITLE
allow string input in bytes fields

### DIFF
--- a/bench/bench.proto
+++ b/bench/bench.proto
@@ -24,4 +24,5 @@ message Test {
   optional Lol meh = 6;
   optional uint32 hello = 3;
   optional string foo = 1;
+  optional bytes payload = 7;
 }

--- a/bench/index.js
+++ b/bench/index.js
@@ -10,6 +10,7 @@ var run = function(name, encode, decode) {
   var EXAMPLE = {
     foo: 'hello',
     hello: 42,
+    payload: new Buffer('a'),
     meh: {
       b: {
         tmp: {

--- a/encodings.js
+++ b/encodings.js
@@ -15,18 +15,25 @@ var encoder = function(type, encode, decode, encodingLength) {
 exports.make = encoder
 
 exports.bytes = function(tag) {
+  var bufferLength = function(val) {
+    return Buffer.isBuffer(val) ? val.length : Buffer.byteLength(val)
+  }
+
   var encodingLength = function(val) {
-    return varint.encodingLength(val.length) + val.length
+    var len = bufferLength(val)
+    return varint.encodingLength(len) + len
   }
 
   var encode = function(val, buffer, offset) {
     var oldOffset = offset
+    var len = bufferLength(val)
 
-    varint.encode(val.length, buffer, offset)
+    varint.encode(len, buffer, offset)
     offset += varint.encode.bytes
 
-    val.copy(buffer, offset)
-    offset += val.length
+    if (Buffer.isBuffer(val)) val.copy(buffer, offset)
+    else buffer.write(val, offset, len)
+    offset += len
 
     encode.bytes = offset - oldOffset
     return buffer

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,7 +15,14 @@ tape('basic encode', function(t) {
     meeeh: 42
   })
 
+  var b3 = Basic.encode({
+    num: 1,
+    payload: 'lol',
+    meeeh: 42
+  })
+
   t.same(b2, b1)
+  t.same(b3, b1)
   t.end()
 })
 


### PR DESCRIPTION
It is really annoying having to write `new Buffer()`, when there is a bytes filed. This PR allows strings to be used instead of buffers.

The negative side of this, is that `encodings.bytes` becomes polymorphic (string, buffer) and it could have a performance penalty. 
However after benchmarking it, I have only seen a performance penalty if both string and buffer are used in the same encoding on bytes fields. So since current users are monomorphic (they are already restricted to buffers) the practical performance is the same.