### PR TITLE
Move brfs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "generate-object-property": "^1.2.0",
     "protocol-buffers-schema": "^2.0.1",
     "signed-varint": "^2.0.0",
+    "brfs": "^1.4.0",
     "varint": "^4.0.0"
   },
   "devDependencies": {
-    "brfs": "^1.4.0",
     "tape": "^3.0.3"
   },
   "scripts": {


### PR DESCRIPTION
If it's not in dependencies, it's not installed when `protocol-buffer` is installed as dependency. This prevents use with browserify.

I haven't dug too deeply into it, but maybe brfs is actually not necessary as a browserify transform (but that's not the topic of this PR).