### PR TITLE
NaN should not be considered defined

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -28,7 +28,7 @@ var skip = function(type, buffer, offset) {
 }
 
 var defined = function(val) {
-  return val !== null && val !== undefined
+  return val !== null && val !== undefined && (typeof val !== "number" || !isNaN(val))
 }
 
 var isString = function(def) {

--- a/test/nan.js
+++ b/test/nan.js
@@ -1,0 +1,31 @@
+﻿var tape = require('tape')
+var path = require('path')
+var protobuf = require('../')
+
+var protoStr = 'message MyMessage {\n' +
+  '  optional uint32 my_number = 1;\n' +
+  '  required string my_other = 2;\n' +
+  '}'
+  
+
+var messages = protobuf(protoStr)
+
+tape('NaN considered not defined', function (t) {
+  var didFail = false
+  var error
+  var encoded
+  var decoded
+  var testString = 'hello!'
+  var properResult = new Buffer([0x12, 0x06, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x21]);
+  try {
+    encoded = messages.MyMessage.encode({ my_number: NaN, my_other: testString })
+    decoded = messages.MyMessage.decode(encoded)
+    t.same(decoded.my_other, testString, 'object is parsable')
+    t.same(encoded, properResult, 'object was encoded properly')
+  } catch (e) {
+    error = e
+    didFail = true
+  }
+  t.same(didFail, false, error ? 'parsing error: ' + error.toString() : 'no parsing error')
+  t.end()
+})


### PR DESCRIPTION
Spent four days tracking this down :-)

Turns out the library is considered `NaN` as defined. Since

> \> NaN !== null
> true
> \> NaN !== undefined
> true

This fix will check for `NaN` to make sure that it is not considered defined. When it is considered defined, it has a very weird result on the buffer created - try it for yourself ;-)