### PR TITLE
Fix bug with string value of packed option.

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -209,7 +209,7 @@ module.exports = function (schema, extraEncodings) {
     })
 
     forEach(function (e, f, val, i) {
-      var packed = f.repeated && f.options && f.options.packed
+      var packed = f.repeated && f.options && f.options.packed && f.options.packed !== 'false'
       var hl = varint.encodingLength(f.tag << 3 | e.type)
 
       if (f.required) encodingLength('if (!defined(%s)) throw new Error(%s)', val, JSON.stringify(f.name + ' is required'))
@@ -287,7 +287,7 @@ module.exports = function (schema, extraEncodings) {
       if (f.required) encode('if (!defined(%s)) throw new Error(%s)', val, JSON.stringify(f.name + ' is required'))
       else encode('if (defined(%s)) {', val)
 
-      var packed = f.repeated && f.options && f.options.packed
+      var packed = f.repeated && f.options && f.options.packed && f.options.packed !== 'false'
       var p = varint.encode(f.tag << 3 | 2)
       var h = varint.encode(f.tag << 3 | e.type)
       var j
@@ -413,7 +413,7 @@ module.exports = function (schema, extraEncodings) {
       ('switch (tag) {')
 
     forEach(function (e, f, val, i) {
-      var packed = f.repeated && f.options && f.options.packed
+      var packed = f.repeated && f.options && f.options.packed && f.options.packed !== 'false'
 
       decode('case %d:', f.tag)
 

--- a/test/notpacked.js
+++ b/test/notpacked.js
@@ -1,0 +1,33 @@
+var tape = require('tape')
+var fs = require('fs')
+var protobuf = require('../')
+var NotPacked = protobuf(fs.readFileSync(__dirname + '/test.proto')).NotPacked
+var FalsePacked = protobuf(fs.readFileSync(__dirname + '/test.proto')).FalsePacked
+
+tape('NotPacked encode + FalsePacked decode', function (t) {
+  var b1 = NotPacked.encode({
+    id: [ 9847136125 ],
+    value: 10000
+  })
+
+  var o1 = FalsePacked.decode(b1)
+
+  t.same(o1.id.length, 1)
+  t.same(o1.id[0], 9847136125)
+
+  t.end()
+})
+
+tape('FalsePacked encode + NotPacked decode', function (t) {
+  var b1 = FalsePacked.encode({
+    id: [ 9847136125 ],
+    value: 10000
+  })
+
+  var o1 = NotPacked.decode(b1)
+
+  t.same(o1.id.length, 1)
+  t.same(o1.id[0], 9847136125)
+
+  t.end()
+})

--- a/test/test.proto
+++ b/test/test.proto
@@ -41,6 +41,15 @@ message Packed {
   repeated string packed = 2 [packed=true];
 }
 
+message NotPacked {
+  repeated int64 id = 2;
+  optional int64 value = 5;
+}
+message FalsePacked {
+  repeated int64 id = 2 [packed=false];
+  optional int64 value = 5;
+}
+
 enum FOO {
   A = 1;
   B = 2;


### PR DESCRIPTION
When for a certain field option `packed` in explicitly set to "false", encoder/decoder must consider this field as not packed.