### PR TITLE
Add no-var to eslint rule disables

### DIFF
--- a/compile-to-js.js
+++ b/compile-to-js.js
@@ -25,6 +25,7 @@ function compile (messages, opts) {
   out += '/* eslint-disable indent */' + os.EOL
   out += '/* eslint-disable no-redeclare */' + os.EOL
   out += '/* eslint-disable camelcase */' + os.EOL
+  out += '/* eslint-disable no-var */' + os.EOL
   out += os.EOL
   if (!encodings) out += '// Remember to `npm install --save protocol-buffers-encodings`' + os.EOL
   out += 'var encodings = require(\'' + (encodings || 'protocol-buffers-encodings') + '\')' + os.EOL


### PR DESCRIPTION
When I use this repo together with `standard` (and a lot of other eslint configs) it ends up complaining about the use of `var`.

This adds a disable line so that linters won't complain about the use of `var`