### PR TITLE
chore: switching from travis to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 'lts/*'
+    - run: npm -v
+    - run: npm i
+    - run: npm run test
+    - run: npm run bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "9"
-  - "8"
-  - "6"
-  - "4"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 npm install protocol-buffers
 ```
 
-[![build status](https://travis-ci.org/mafintosh/protocol-buffers.svg?branch=master)](https://travis-ci.org/mafintosh/protocol-buffers)
+[![build status](https://github.com/mafintosh/protocol-buffers/actions/workflows/test.yml/badge.svg)](https://github.com/mafintosh/protocol-buffers/actions/workflows/test.yml)
 ![dat](http://img.shields.io/badge/Development%20sponsored%20by-dat-green.svg?style=flat)
 
 ## Usage


### PR DESCRIPTION
For better visibility of the ci tests run.

Also updates the node versions from 4 ~ 17 with lts/*.

Successful run here: https://github.com/martinheidegger/protocol-buffers/actions/runs/2015499159